### PR TITLE
Refactored fixity workers.

### DIFF
--- a/exe/archival_storage_fcheck_s3
+++ b/exe/archival_storage_fcheck_s3
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+# rubocop:disable all
+
 require 'pp'
 require 'json'
 
@@ -14,6 +16,8 @@ require 'archival_storage_ingest/manifests/manifests'
 class FixityCheck
   MANIFEST_PATH = '/cul/app/cular/manifest'
 
+  attr_reader :s3, :worker
+
   def s3
     @s3 ||= S3Manager.new('s3-cular')
   end
@@ -24,12 +28,11 @@ class FixityCheck
 
   # @return [list of manifest objects]
   def manifest_list
-    IO.readlines('collection_manifests_math_africana.txt')
+    IO.readlines('collection_manifests.txt')
   end
 
   def generate_fixity_manifest(msg)
-    object_keys = s3.list_object_keys(msg.collection_s3_prefix)
-    worker.generate_manifest(object_keys)
+    worker.generate_manifest(msg)
   end
 
   def manifests
@@ -76,8 +79,7 @@ class FixityCheck
   def check_all_manifests
     paths = manifests
 
-    @bars = TTY::ProgressBar.new('Checking [:bar] :elapsed, :eta')
-    bars.iterate(paths) { |p| check_manifest p }
+    paths.each(&method(:check_manifest))
   end
 end
 

--- a/exe/archival_storage_fcheck_s3
+++ b/exe/archival_storage_fcheck_s3
@@ -37,9 +37,6 @@ class FixityCheck
       path.strip!
       dirs = path.split('/') # TODO: Fix this part to be more generic
       data_path = dirs[0..4].join('/') # "root" is element 0, cul is element 1, so depositor is 4
-      depcol = dirs[4...-1].join('/')
-
-      manifest = dirs[-1]
       collection = dirs[-2]
       depositor = File.join(dirs[4...-2])
       ingest_manifest = File.join(dirs[4..-1])
@@ -57,14 +54,15 @@ class FixityCheck
     dep = path.depositor
     col = path.collection
 
-    manifest_json = manifest.to_old_manifest(dep, col).to_json
-    manifest_fix = Manifests::Manifest.new(filename: 'fixity', json: StringIO.new(manifest_json))
+    fixity_manifest_json = manifest.to_old_manifest(dep, col).to_json
+    fixity_manifest = Manifests::Manifest.new(filename: 'fixity', json: StringIO.new(fixity_manifest_json))
+
     ingest_manifest_json = s3.retrieve_file(path.ingest_manifest)
     ingest_manifest = Manifests::Manifest.new(filename: 'collection', json: ingest_manifest_json)
 
-    difference = manifest_fix.diff(ingest_manifest)
+    difference = fixity_manifest.diff(ingest_manifest)
 
-    if difference.keys.length != 1 || difference['fixity'].keys.length != 1
+    unless difference.keys.length == 1 && difference['fixity'].keys.length == 1
       pp difference
       raise "#{dep} #{col} failed!"
     end

--- a/exe/archival_storage_fcheck_s3
+++ b/exe/archival_storage_fcheck_s3
@@ -1,0 +1,87 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'pp'
+require 'json'
+
+require 'archival_storage_ingest'
+require 'archival_storage_ingest/workers/fixity_worker'
+require 'archival_storage_ingest/s3/s3_manager'
+require 'archival_storage_ingest/manifests/manifests'
+
+# require 'aws-sdk-s3'
+
+class FixityCheck
+  MANIFEST_PATH = '/cul/app/cular/manifest'
+
+  def s3
+    @s3 ||= S3Manager.new('s3-cular')
+  end
+
+  def worker
+    @worker ||= FixityWorker::S3FixityGenerator.new(s3)
+  end
+
+  # @return [list of manifest objects]
+  def manifest_list
+    IO.readlines('collection_manifests_math_africana.txt')
+  end
+
+  def generate_fixity_manifest(msg)
+    object_keys = s3.list_object_keys(msg.collection_s3_prefix)
+    worker.generate_manifest(object_keys)
+  end
+
+  def manifests
+    manifest_list.reverse.map do |path|
+      path.strip!
+      dirs = path.split('/') # TODO: Fix this part to be more generic
+      data_path = dirs[0..4].join('/') # "root" is element 0, cul is element 1, so depositor is 4
+      depcol = dirs[4...-1].join('/')
+
+      manifest = dirs[-1]
+      collection = dirs[-2]
+      depositor = File.join(dirs[4...-2])
+      ingest_manifest = File.join(dirs[4..-1])
+
+      IngestMessage::SQSMessage.new(
+        data_path: data_path,
+        depositor: depositor,
+        collection: collection,
+        ingest_manifest: ingest_manifest
+      )
+    end
+  end
+
+  def compare_manifest(manifest, path)
+    dep = path.depositor
+    col = path.collection
+
+    manifest_json = manifest.to_old_manifest(dep, col).to_json
+    manifest_fix = Manifests::Manifest.new(filename: 'fixity', json: StringIO.new(manifest_json))
+    ingest_manifest_json = s3.retrieve_file(path.ingest_manifest)
+    ingest_manifest = Manifests::Manifest.new(filename: 'collection', json: ingest_manifest_json)
+
+    difference = manifest_fix.diff(ingest_manifest)
+
+    if difference.keys.length != 1 || difference['fixity'].keys.length != 1
+      pp difference
+      raise "#{dep} #{col} failed!"
+    end
+  end
+
+  def check_manifest(path)
+    manifest = generate_fixity_manifest(path)
+    compare_manifest(manifest, path)
+  end
+
+  def check_all_manifests
+    paths = manifests
+
+    @bars = TTY::ProgressBar.new('Checking [:bar] :elapsed, :eta')
+    bars.iterate(paths) { |p| check_manifest p }
+  end
+end
+
+checker = FixityCheck.new
+checker.check_all_manifests

--- a/lib/archival_storage_ingest/workers/fixity_compare_worker.rb
+++ b/lib/archival_storage_ingest/workers/fixity_compare_worker.rb
@@ -19,7 +19,7 @@ module FixityCompareWorker
 
       raise IngestException, 'Ingest and SFS manifests do not match' unless ingest_manifest.flattened == sfs_manifest.flattened
 
-      raise IngestException, 'Ingest and S3 manifests do not match' unless s3_manifest.flattened == ingest_manifest.flattened
+      raise IngestException, 'Ingest and S3 manifests do not match' unless ingest_manifest.flattened == s3_manifest.flattened
 
       true
     rescue Aws::S3::Errors::NoSuchKey

--- a/lib/archival_storage_ingest/workers/fixity_worker.rb
+++ b/lib/archival_storage_ingest/workers/fixity_worker.rb
@@ -69,7 +69,7 @@ module FixityWorker
 
     def object_key_paths(msg)
       @s3_manager.list_object_keys(msg.collection_s3_prefix)
-        .map { |x| [x, x] }.to_h
+                 .map { |x| [x, x] }.to_h
     end
   end
 
@@ -100,9 +100,9 @@ module FixityWorker
       path_to_trim = Pathname.new(msg.dest_path)
 
       Find.find(assets_dir)
-        .reject { |path| File.directory?(path) }
-        .map { |path| [Pathname.new(path).relative_path_from(path_to_trim).to_s, path] }
-        .to_h
+          .reject { |path| File.directory?(path) }
+          .map { |path| [Pathname.new(path).relative_path_from(path_to_trim).to_s, path] }
+          .to_h
     end
   end
 end

--- a/spec/fixity_worker_spec.rb
+++ b/spec/fixity_worker_spec.rb
@@ -88,8 +88,7 @@ RSpec.describe 'FixityWorker' do # rubocop:disable BlockLength
 
     context 'when generating manifest' do
       it 'returns manifest' do
-        object_keys = s3_manager.list_object_keys(msg.collection_s3_prefix)
-        manifest = worker.generate_manifest(object_keys)
+        manifest = worker.generate_manifest(msg)
         # expect(manifest.manifest_hash).to eq(expected_old_hash)
         expect(manifest.to_old_manifest(depositor, collection)).to eq(expected_old_hash)
       end


### PR DESCRIPTION
I have refactored the fixity workers to make the code between the S3 and SFS workers exist in a common class, and only S3/SFS-specific details are implemented in the individual classes.

To implement a new fixity worker type, you just need to implement the three methods:

- `worker_type`, which returns the manifest-type specific suffix (S3, SFS, Ingest) used in the manifest file name,
- `object_key_paths(msg)`, which returns a hash of object keys and paths to be included in the manifest
- `calculate_checksum(path)`, which calculates the SHA1 hexdigest for a path.

