### PR TITLE
Update upload_asif_archive_size to use upload_string methodology

### DIFF
--- a/lib/archival_storage_ingest/s3/s3_manager.rb
+++ b/lib/archival_storage_ingest/s3/s3_manager.rb
@@ -51,8 +51,10 @@ class S3Manager
     _upload_file(bucket: @asif_s3_bucket, s3_key: s3_key, file: manifest_file)
   end
 
-  def upload_asif_archive_size(s3_key:, archive_size_file:)
-    _upload_file(bucket: @asif_archive_size_s3_bucket, s3_key: s3_key, file: archive_size_file)
+  def upload_asif_archive_size(s3_key, data)
+    s3.bucket(@asif_archive_size_s3_bucket).object(s3_key).put(body: data)
+  rescue Aws::S3::Errors::ServiceError => e
+    raise IngestException, "Archive Size S3 upload data stream failed!\n#{parse_s3_error(e)}"
   end
 
   def upload_string(s3_key, data)


### PR DESCRIPTION
Changed ASIF archive size upload to match upload_string methodology because JSON data is passed in not a file.