### PR TITLE
Add env-configurable default path

### DIFF
--- a/exe/archival_storage_ingest
+++ b/exe/archival_storage_ingest
@@ -15,9 +15,12 @@ require 'archival_storage_ingest/logs/application_logger'
 
 # We assume the ingest is initiated from server farm VM.
 application_logger = nil
+# The following populates configuration values for ArchivalStorageIngest.
+# config is an instance of ArchivalStorageIngest::Configuration, passed in
+# via yield.
 ArchivalStorageIngest.configure do |config|
   config.log_path = ENV['asi_ingest_queue_log_path'] ||
-                    '/cul/app/archival_storage_ingest/logs/ingest_queue.log'
+                    "#{ENV['default_cular_log_path']}/ingest_queue.log"
   config.dry_run = ENV['asi_ingest_queue_dry_run'] || false
 
   config_params = {
@@ -26,6 +29,8 @@ ArchivalStorageIngest.configure do |config|
     asi_develop: ENV['asi_develop'] || ENV['asi_queue_develop'],
     asi_sandbox: ENV['asi_sandbox'] || ENV['asi_queue_sandbox']
   }
+  # ConfigureHelper sets up and adds more config values: stage, queue names, develop,
+  #  debug, s3_bucket.
   configure_helper = IngestUtils::ConfigureHelper.new(config_params)
   configure_helper.configure(config)
 

--- a/exe/archival_storage_move_message
+++ b/exe/archival_storage_move_message
@@ -9,7 +9,7 @@ require 'archival_storage_ingest/messages/queues'
 
 ArchivalStorageIngest.configure do |config|
   config.log_path = ENV['asi_move_message_log_path'] ||
-                    '/cul/app/archival_storage_ingest/logs/move_message.log'
+                    "#{ENV['default_cular_log_path']}/move_message.log"
   config.dry_run = ENV['asi_move_message_dry_run'] || false
   config.debug = ENV['asi_move_message_debug'] || false
   config.message_queue_name = ''

--- a/exe/archival_storage_periodic_fixity_check
+++ b/exe/archival_storage_periodic_fixity_check
@@ -17,7 +17,7 @@ require 'archival_storage_ingest/logs/application_logger'
 application_logger = nil
 ArchivalStorageIngest.configure do |config|
   config.log_path = ENV['asi_ingest_queue_log_path'] ||
-                    '/cul/app/archival_storage_ingest/logs/ingest_queue.log'
+                    "#{ENV['default_cular_log_path']}/ingest_queue.log"
   config.dry_run = ENV['asi_ingest_queue_dry_run'] || false
 
   config_params = {

--- a/exe/archival_storage_server_ingest
+++ b/exe/archival_storage_server_ingest
@@ -9,7 +9,7 @@ require 'archival_storage_ingest/workers/ingest_worker'
 require 'archival_storage_ingest/logs/application_logger'
 
 ArchivalStorageIngest.configure do |config|
-  config.log_path = ENV['asi_ingest_log_path'] || '/cul/app/archival_storage_ingest/logs/ingest.log'
+  config.log_path = ENV['asi_ingest_log_path'] || "#{ENV['default_cular_log_path']}/ingest.log"
   config.dry_run = ENV['asi_ingest_dry_run'] || false
   config.polling_interval = ENV['asi_ingest_polling_interval'].to_i if ENV['asi_ingest_polling_interval']
   config.inhibit_file = ENV['asi_ingest_inhibit_file'] || '/cul/app/archival_storage_ingest/control/ingest.inhibit'

--- a/exe/archival_storage_server_ingest_fixity_s3
+++ b/exe/archival_storage_server_ingest_fixity_s3
@@ -10,7 +10,7 @@ require 'archival_storage_ingest/logs/application_logger'
 
 ArchivalStorageIngest.configure do |config|
   config.log_path = ENV['asi_ingest_fixity_s3_log_path'] ||
-                    '/cul/app/archival_storage_ingest/logs/ingest_fixity_s3.log'
+                    "#{ENV['default_cular_log_path']}/ingest_fixity_s3.log"
   config.dry_run = ENV['asi_ingest_fixity_s3_dry_run'] || false
   config.polling_interval = ENV['asi_ingest_fixity_s3_polling_interval'].to_i if
                             ENV['asi_ingest_fixity_s3_polling_interval']

--- a/exe/archival_storage_server_ingest_fixity_sfs
+++ b/exe/archival_storage_server_ingest_fixity_sfs
@@ -10,7 +10,7 @@ require 'archival_storage_ingest/logs/application_logger'
 
 ArchivalStorageIngest.configure do |config|
   config.log_path = ENV['asi_ingest_fixity_sfs_log_path'] ||
-                    '/cul/app/archival_storage_ingest/logs/ingest_fixity_sfs.log'
+                    "#{ENV['default_cular_log_path']}/ingest_fixity_sfs.log"
   config.dry_run = ENV['asi_ingest_fixity_sfs_dry_run'] || false
   config.polling_interval = ENV['asi_ingest_fixity_sfs_polling_interval'].to_i if
                             ENV['asi_ingest_fixity_sfs_polling_interval']

--- a/exe/archival_storage_server_ingest_m2m
+++ b/exe/archival_storage_server_ingest_m2m
@@ -13,7 +13,7 @@ storage_schema = ENV['asi_storage_schema'] || '/cul/app/cular-metadata/manifest_
 
 ArchivalStorageIngest.configure do |config| # rubocop:disable Metrics/BlockLength
   config.log_path = ENV['asi_ingest_m2m_log_path'] ||
-                    '/cul/app/archival_storage_ingest/logs/ingest_m2m.log'
+                    "#{ENV['default_cular_log_path']}/ingest_m2m.log"
   config.dry_run = ENV['asi_ingest_m2m_dry_run'] || false
   config.polling_interval = ENV['asi_ingest_m2m_polling_interval'].to_i if
                             ENV['asi_ingest_m2m_polling_interval']

--- a/exe/archival_storage_server_log
+++ b/exe/archival_storage_server_log
@@ -10,7 +10,7 @@ require 'archival_storage_ingest/workers/log_worker'
 
 ArchivalStorageIngest.configure do |config| # rubocop:disable Metrics/BlockLength
   config.log_path = ENV['asi_ingest_logger_log_path'] ||
-                    '/cul/app/archival_storage_ingest/logs/logger.log'
+                    "#{ENV['default_cular_log_path']}/logger.log"
   config.dry_run = ENV['asi_ingest_logger_dry_run'] || false
   config.polling_interval = ENV['asi_ingest_logger_polling_interval'].to_i if ENV['asi_ingest_logger_polling_interval']
   config.inhibit_file = ENV['asi_ingest_logger_inhibit_file'] ||

--- a/exe/archival_storage_server_periodic_fixity_check
+++ b/exe/archival_storage_server_periodic_fixity_check
@@ -17,7 +17,7 @@ end
 
 ArchivalStorageIngest.configure do |config|
   config.log_path = ENV['asi_ingest_periodic_fixity_check_path'] ||
-                    '/cul/app/archival_storage_ingest/logs/periodic_fixity_check.log'
+                    "#{ENV['default_cular_log_path']}/periodic_fixity_check.log"
   config.dry_run = ENV['asi_periodic_fixity_dry_run'] || false
   config.polling_interval = ENV['asi_periodic_fixity_polling_interval'].to_i if ENV['asi_periodic_fixity_polling_interval']
   config.inhibit_file = ENV['asi_periodic_fixity_inhibit_file'] ||

--- a/exe/archival_storage_server_periodic_fixity_comparison
+++ b/exe/archival_storage_server_periodic_fixity_comparison
@@ -17,7 +17,7 @@ if ENV['asi_periodic_fixity_slack_web_hook'].nil?
 end
 
 log_path = ENV['asi_periodic_fixity_comparison_log_path'] ||
-           '/cul/app/archival_storage_ingest/logs/periodic_fixity_comparison.log'
+           "#{ENV['default_cular_log_path']}/periodic_fixity_comparison.log"
 polling_interval = ENV['asi_periodic_fixity_comparison_polling_interval'].to_i if
   ENV['asi_periodic_fixity_comparison_polling_interval']
 inhibit_file = ENV['asi_periodic_fixity_comparison_inhibit_file'] ||

--- a/exe/archival_storage_server_periodic_fixity_s3
+++ b/exe/archival_storage_server_periodic_fixity_s3
@@ -17,7 +17,7 @@ end
 
 ArchivalStorageIngest.configure do |config|
   config.log_path = ENV['asi_periodic_fixity_s3_log_path'] ||
-                    '/cul/app/archival_storage_ingest/logs/periodic_fixity_s3.log'
+                    "#{ENV['default_cular_log_path']}/periodic_fixity_s3.log"
   config.dry_run = ENV['asi_periodic_fixity_s3_dry_run'] || false
   config.polling_interval = ENV['asi_periodic_fixity_s3_polling_interval'].to_i if
                             ENV['asi_periodic_fixity_s3_polling_interval']

--- a/exe/archival_storage_server_periodic_fixity_sfs
+++ b/exe/archival_storage_server_periodic_fixity_sfs
@@ -17,7 +17,7 @@ end
 
 ArchivalStorageIngest.configure do |config|
   config.log_path = ENV['asi_periodic_fixity_sfs_log_path'] ||
-                    '/cul/app/archival_storage_ingest/logs/periodic_fixity_sfs.log'
+                    "#{ENV['default_cular_log_path']}/periodic_fixity_sfs.log"
   config.dry_run = ENV['asi_periodic_fixity_sfs_dry_run'] || false
   config.polling_interval = ENV['asi_periodic_fixity_sfs_polling_interval'].to_i if
                             ENV['asi_periodic_fixity_sfs_polling_interval']

--- a/exe/archival_storage_server_transfer_s3
+++ b/exe/archival_storage_server_transfer_s3
@@ -10,7 +10,7 @@ require 'archival_storage_ingest/logs/application_logger'
 
 ArchivalStorageIngest.configure do |config|
   config.log_path = ENV['asi_transfer_s3_log_path'] ||
-                    '/cul/app/archival_storage_ingest/logs/transfer_s3.log'
+                    "#{ENV['default_cular_log_path']}/transfer_s3.log"
   config.dry_run = ENV['asi_transfer_s3_dry_run'] || false
   config.polling_interval = ENV['asi_transfer_s3_polling_interval'].to_i if
                             ENV['asi_transfer_s3_polling_interval']

--- a/exe/dead_letter_monitor
+++ b/exe/dead_letter_monitor
@@ -8,7 +8,7 @@ require 'archival_storage_ingest/monitor/dead_letter_monitor'
 
 ArchivalStorageIngest.configure do |config|
   config.log_path = ENV['asi_dead_letter_monitor_log_path'] ||
-                    '/cul/app/archival_storage_ingest/logs/dead_letter_monitor.log'
+                    "#{ENV['default_cular_log_path']}/dead_letter_monitor.log"
 end
 
 dead_letter_queues =

--- a/lib/archival_storage_ingest/logs/archival_storage_ingest_logger.rb
+++ b/lib/archival_storage_ingest/logs/archival_storage_ingest_logger.rb
@@ -4,7 +4,11 @@ require 'logger'
 
 # Archival storage ingest loggers
 module ArchivalStorageIngestLogger
-  DEFAULT_LOG_PATH = '/cul/app/archival_storage_ingest/logs/default.log'
+  DEFAULT_LOG_PATH = if ENV['default_cular_log_path']
+                       "#{ENV['default_cular_log_path']}/default.log"
+                     else
+                       '/cul/app/archival_storage_ingest/logs/default.log'
+                     end
 
   def self.get_file_logger(config)
     log_path = config.log_path.nil? ? DEFAULT_LOG_PATH : config.log_path


### PR DESCRIPTION
This provides a simple way to configure a default path for all log files at once, rather than having to add env variables for each path separately.