### PR TITLE
CULAR-5226: Remove locations from manifest

### DIFF
--- a/lib/archival_storage_ingest/manifests/manifests.rb
+++ b/lib/archival_storage_ingest/manifests/manifests.rb
@@ -40,7 +40,7 @@ module Manifests
     "_EM_#{dep}_#{col}.json"
   end
 
-  class Manifest # rubocop:disable Metrics/ClassLength
+  class Manifest
     attr_accessor :collection_id, :depositor, :steward, :packages, :documentation
 
     # initialize from the json string

--- a/lib/archival_storage_ingest/manifests/manifests.rb
+++ b/lib/archival_storage_ingest/manifests/manifests.rb
@@ -8,7 +8,7 @@ require 'open3'
 require 'pathname'
 
 module Manifests
-  BLANK_JSON_TEXT = '{"locations":[],"packages":[]}'
+  BLANK_JSON_TEXT = '{"packages":[]}'
   IDENTIFY_TOOL = 'Apache Tika 2.1.0'
   MANIFEST_TYPE_INGEST = 'ingest_manifest'
   MANIFEST_TYPE_STORAGE = 'storage_manifest'
@@ -41,7 +41,7 @@ module Manifests
   end
 
   class Manifest # rubocop:disable Metrics/ClassLength
-    attr_accessor :collection_id, :depositor, :steward, :locations, :packages, :documentation
+    attr_accessor :collection_id, :depositor, :steward, :packages, :documentation
 
     # initialize from the json string
     def initialize(json_text: BLANK_JSON_TEXT) # rubocop:disable Metrics/MethodLength
@@ -50,8 +50,6 @@ module Manifests
       @depositor = json_hash[:depositor]
       @documentation = json_hash[:documentation]
       @steward = json_hash[:steward]
-      @locations = json_hash[:locations]
-      @locations = [] if @locations.nil?
       @packages = if json_hash[:packages]
                     json_hash[:packages].map do |package|
                       Manifests::Package.new(package:)
@@ -155,7 +153,7 @@ module Manifests
       IngestUtils.compact_blank({
                                   depositor:, collection_id:,
                                   steward:, documentation:,
-                                  locations:, number_packages:,
+                                  number_packages:,
                                   packages: packages.map(&:to_json_hash_storage)
                                 })
     end

--- a/lib/archival_storage_ingest/preingest/base_env_initializer.rb
+++ b/lib/archival_storage_ingest/preingest/base_env_initializer.rb
@@ -68,10 +68,6 @@ module Preingest
       "s3://s3-cular/#{depositor}/#{collection_id}"
     end
 
-    def full_sfs_location(sfs_location:)
-      "smb://files.cornell.edu/lib/#{sfs_location}/#{depositor}/#{collection_id}"
-    end
-
     def _initialize_config(im_path:)
       ingest_params = generate_config(ingest_manifest_path: im_path)
       ingest_params_file = prepare_config_path

--- a/lib/archival_storage_ingest/workers/fixity_worker.rb
+++ b/lib/archival_storage_ingest/workers/fixity_worker.rb
@@ -14,7 +14,6 @@ require 'pathname'
 module FixityWorker
   FIXITY_TEMPORARY_PACKAGE_ID = 'fixity_temporary_package'
   FIXITY_MANIFEST_TEMPLATE = {
-    locations: [],
     packages: [
       {
         package_id: FIXITY_TEMPORARY_PACKAGE_ID,

--- a/lib/misc/convert_manifest.rb
+++ b/lib/misc/convert_manifest.rb
@@ -37,9 +37,6 @@ module ConvertManifest
       col = depcolsplit[-1]
       dep = depcolsplit[0..-2].join('/')
       documentation = documentation_pid(filename:)
-
-      locations = populate_locations(collection['locations'])
-
       items = collection['items']
       packs = convert_packages(items, depth, nil)
 
@@ -47,23 +44,10 @@ module ConvertManifest
         steward: collection['steward'],
         depositor: dep,
         collection_id: col,
-        locations:,
         documentation:,
         number_packages: packs.length,
         packages: packs
       }.compact
-    end
-
-    def populate_locations(locations)
-      return (locations || {}).keys if (locations['s3']).nil?
-
-      locs = []
-      locations.each_key do |storage_type|
-        locations[storage_type].each do |loc|
-          locs << loc['uri']
-        end
-      end
-      locs
     end
 
     def convert_manifest(filename:, csv:, data_root:, depth: 1)

--- a/spec/convert_manifest_spec.rb
+++ b/spec/convert_manifest_spec.rb
@@ -34,25 +34,6 @@ RSpec.describe 'ConvertManifest' do
       it 'gets the documentation' do
         expect(@manifest['documentation']).to eq('cular:1')
       end
-
-      it 'gets the locations' do
-        expect(@manifest['locations']).to contain_exactly(
-          's3://s3-cular/MATH/LecturesEvents',
-          'smb://files.cornell.edu/lib/archival01/MATH/LecturesEvents'
-        )
-      end
-
-      it 'gets the locations in new format' do
-        manifest_json = JSON.pretty_generate(
-          convert_manifest.convert_manifest_to_new_hash(filename: resource('4ItemsFull.json'), depth: 1)
-        )
-        manifest = JSON.parse(manifest_json)
-
-        expect(manifest['locations']).to contain_exactly(
-          's3://s3-cular/RMC/RMA/RMA00507_Dexter_Simpson_Kimball_papers',
-          'smb://files.cornell.edu/lib/archival02/RMC/RMA/RMA00507_Dexter_Simpson_Kimball_papers'
-        )
-      end
     end
 
     context 'when looking at packages' do

--- a/spec/deploy_collection_manifest_spec.rb
+++ b/spec/deploy_collection_manifest_spec.rb
@@ -18,6 +18,7 @@ def get_mom(mom)
   f = File.open(mom, 'r')
   mom_text = f.read
   f.close
+  puts "mom-parsed: #{JSON.parse(mom_text, symbolize_names: true)}"
   JSON.parse(mom_text, symbolize_names: true)
 end
 
@@ -41,7 +42,7 @@ RSpec.describe 'CollectionManifestDeployer' do
   let(:man_of_man_source) { resolve_filename(%w[manifests manifest_of_manifest.json]) }
   let(:man_of_man) { resolve_filename(%w[manifests manifest_of_manifest_copy.json]) }
   let(:old_manifest_sha1) { 'deadbeef' }
-  let(:new_manifest_sha1) { '921d09399fdba978bb0863c98f372c9c211f8573' }
+  let(:new_manifest_sha1) { '1d2fcfde749ba5c0c04458e88544d5f935a120f8' }
   let(:asif_bucket) { 's3-cular-invalid' }
   let(:s3_manager) do
     local_root = File.join(File.dirname(__FILE__), 'resources', 'cloud')

--- a/spec/deploy_collection_manifest_spec.rb
+++ b/spec/deploy_collection_manifest_spec.rb
@@ -18,7 +18,6 @@ def get_mom(mom)
   f = File.open(mom, 'r')
   mom_text = f.read
   f.close
-  puts "mom-parsed: #{JSON.parse(mom_text, symbolize_names: true)}"
   JSON.parse(mom_text, symbolize_names: true)
 end
 

--- a/spec/ingest_env_initializer_spec.rb
+++ b/spec/ingest_env_initializer_spec.rb
@@ -38,7 +38,6 @@ RSpec.describe 'IngestEnvInitializer' do
   let(:merged_manifest) { File.join(source_data, '_EM_merged_collection_manifest.json') }
   let(:expected_ingest_config) { File.join(source_data, 'expected_ingest_config.yaml') }
   let(:data) { File.join(source_data, depositor, collection) }
-  let(:sfs_location) { 'archival0x' }
   let(:ticket_id) { 'CULAR-xxxx' }
   let(:dir_to_clean) { File.join(ingest_root, depositor) }
   let(:storage_schema) { File.join(base_dir, 'resources', 'schema', 'manifest_schema_storage.json') }

--- a/spec/merge_manifest_spec.rb
+++ b/spec/merge_manifest_spec.rb
@@ -84,19 +84,6 @@ RSpec.describe 'MergeManifest' do
         'phys_coll_id' => 'RMA02471',
         'steward' => 'eef46',
         'number_files' => 5,
-        'locations' => {
-          's3' => [
-            {
-              uri: 's3://s3-cular/RMC/RMA/RMA03487_Cornell_University_Facilities_Construction_Records'
-            }
-          ],
-          'sfs' => [
-            {
-              uri: 'smb://files.cornell.edu/lib/archival02/RMC/' \
-                   'RMA/RMA03487_Cornell_University_Facilities_Construction_Records'
-            }
-          ]
-        },
         'items' => {
           '1001_Barton Hall' => {
             'SUCF 161001 10069_2016_Flooring System Replacement' => {

--- a/spec/resources/disseminate/archival0x/RMC/RMA/RMA01234/_EM_RMC_RMA_RMA01234.json
+++ b/spec/resources/disseminate/archival0x/RMC/RMA/RMA01234/_EM_RMC_RMA_RMA01234.json
@@ -3,10 +3,6 @@
   "collection_id": "RMA01234",
   "steward": "eef46",
   "documentation": "cular:1234",
-  "locations": [
-    "s3://s3-cular/RMC/RMA/RMM01234",
-    "smb://files.cornell.edu/lib/archvial04/RMC/RMA/RMA01234"
-  ],
   "number_packages": 1,
   "packages": [
     {

--- a/spec/resources/m2m/ingest_root/test_depositor/test_collection/manifest/collection_manifest/_EM_test_depositor_test_collection.json
+++ b/spec/resources/m2m/ingest_root/test_depositor/test_collection/manifest/collection_manifest/_EM_test_depositor_test_collection.json
@@ -3,10 +3,6 @@
   "collection_id": "test_collection",
   "steward": "sk274",
   "documentation": "?",
-  "locations": [
-    "s3://s3-cular/test_depositor/test_collection",
-    "smb://files.cornell.edu/lib//Users/sk274/cul/app/archival_storage_ingest/archival-storage-ingest/spec/resources/m2m/sfs_root/test_depositor/test_collection"
-  ],
   "number_packages": 1,
   "packages": [
     {

--- a/spec/resources/m2m/sfs_root/eCommons/eCommons/_EM_eCommons_eCommons.json.orig
+++ b/spec/resources/m2m/sfs_root/eCommons/eCommons/_EM_eCommons_eCommons.json.orig
@@ -3,10 +3,6 @@
   "collection_id": "test_collection",
   "steward": "sk274",
   "documentation": "cular:xxxxx",
-  "locations": [
-    "s3://s3-cular-test/test_depositor/test_collection",
-    "smb://files.cornell.edu/lib/archival0x/test_depositor/test_collection"
-  ],
   "number_packages": 1,
   "packages": [
     {

--- a/spec/resources/manifests/10ItemsFull.json
+++ b/spec/resources/manifests/10ItemsFull.json
@@ -3,10 +3,6 @@
   "depositor": "MATH",
   "collection_id": "LecturesEvents",
   "rights": "TBD",
-  "locations": [
-    "s3://s3-cular/MATH/LecturesEvents",
-    "smb://files.cornell.edu/lib/archival01/MATH/LecturesEvents"
-  ],
   "packages": [
     {
       "package_id": "urn:uuid:8532eee6-81ce-4e6e-9fd5-f6457abfba62",

--- a/spec/resources/manifests/10ItemsOldManifest.json
+++ b/spec/resources/manifests/10ItemsOldManifest.json
@@ -2,14 +2,6 @@
   "MATH/LecturesEvents": {
     "steward": "swr1",
     "number_files": 10,
-    "locations": {
-      "s3://s3-cular/MATH/LecturesEvents": {
-        "date_ingest": "2017-04-05"
-      },
-      "smb://files.cornell.edu/lib/archival01/MATH/LecturesEvents": {
-        "date_ingest": "2017-05-01"
-      }
-    },
     "items": {
       "MATH_2726859_V0098": {
         "MATH_2726859_V0098.mov": {

--- a/spec/resources/manifests/10ItemsReordered.json
+++ b/spec/resources/manifests/10ItemsReordered.json
@@ -2,7 +2,6 @@
   "depositor": "MATH",
   "collection_id": "LecturesEvents",
   "rights": "TBD",
-  "locations": [],
   "packages": [
     {
       "package_id": "urn:uuid:015b120e-e40e-4335-b28a-a0499eaa5de8",

--- a/spec/resources/manifests/4ItemsFull.json
+++ b/spec/resources/manifests/4ItemsFull.json
@@ -3,18 +3,6 @@
     "phys_coll_id": "RMA00507_Dexter_Simpson_Kimball_papers",
     "steward": "eef46",
     "number_files": 4,
-    "locations": {
-      "s3": [
-        {
-          "uri": "s3://s3-cular/RMC/RMA/RMA00507_Dexter_Simpson_Kimball_papers"
-        }
-      ],
-      "sfs": [
-        {
-          "uri": "smb://files.cornell.edu/lib/archival02/RMC/RMA/RMA00507_Dexter_Simpson_Kimball_papers"
-        }
-      ]
-    },
     "items": {
       "RMA00507_WR001": {
         "RMA00507_WR001_wav_exiftool.xml": {

--- a/spec/resources/manifests/9ItemsReordered.json
+++ b/spec/resources/manifests/9ItemsReordered.json
@@ -2,7 +2,6 @@
   "depositor": "MATH",
   "collection_id": "LecturesEvents",
   "rights": "TBD",
-  "locations": [],
   "packages": [
     {
       "package_id": "urn:uuid:f58d4426-9931-429d-8255-81e4e358fcfa",

--- a/spec/resources/manifests/arXiv.json
+++ b/spec/resources/manifests/arXiv.json
@@ -2,10 +2,6 @@
   "depositor": "arXiv",
   "collection_id": "arXiv",
   "steward": "oyr1",
-  "locations": [
-    "s3://s3-cular/arXiv/arXiv",
-    "smb://files.cornell.edu/lib/archival02/arXiv/arXiv"
-  ],
   "number_packages": 4,
   "packages": [
     {

--- a/spec/resources/manifests/arXivOldManifest.json
+++ b/spec/resources/manifests/arXivOldManifest.json
@@ -2,18 +2,6 @@
   "arXiv/arXiv": {
     "steward": "oyr1",
     "number_files": 636,
-    "locations": {
-      "s3": [
-        {
-          "uri": "s3://s3-cular/arXiv/arXiv"
-        }
-      ],
-      "sfs": [
-        {
-          "uri": "smb://files.cornell.edu/lib/archival02/arXiv/arXiv"
-        }
-      ]
-    },
     "items": {
       "9107": {
         "2017-11-22": {

--- a/spec/resources/manifests/comparator/collection_manifest.json
+++ b/spec/resources/manifests/comparator/collection_manifest.json
@@ -2,10 +2,6 @@
   "steward": "eef46",
   "depositor": "RMC/RMA",
   "collection_id": "RMA02205_Cornell_football_films",
-  "locations": [
-    "s3://s3-cular/RMC/RMA/RMA02205_Cornell_football_films",
-    "smb://files.cornell.edu/lib/archival02/RMC/RMA/RMA02205_Cornell_football_films"
-  ],
   "documentation": "cular:1330291",
   "number_packages": 48,
   "packages": [

--- a/spec/resources/manifests/hashdeep_collection_manifest.json
+++ b/spec/resources/manifests/hashdeep_collection_manifest.json
@@ -2,10 +2,6 @@
   "steward": "efe4",
   "depositor": "RMC/RMA",
   "collection_id": "RMA03487_Cornell_University_Facilities_Construction_Records",
-  "locations": [
-    "s3://s3-cular/RMC/RMA/RMA03487_Cornell_University_Facilities_Construction_Records",
-    "smb://files.cornell.edu/lib/archival02/RMC/RMA/RMA03487_Cornell_University_Facilities_Construction_Records"
-  ],
   "documentation": "cular:abcd",
   "number_packages": 3,
   "packages": [

--- a/spec/resources/manifests/nesteddeep.json
+++ b/spec/resources/manifests/nesteddeep.json
@@ -1,18 +1,6 @@
 {
   "arXiv/arXiv": {
     "steward": "oyr1",
-    "locations": {
-      "s3": [
-        {
-          "uri": "s3://s3-cular/arXiv/arXiv"
-        }
-      ],
-      "sfs": [
-        {
-          "uri": "smb://files.cornell.edu/lib/archival02/arXiv/arXiv"
-        }
-      ]
-    },
     "items": {
       "Simpsons": {
         "Season1": {

--- a/spec/resources/manifests/test_depositor/test_collection/_EM_test_depositor_test_collection.json
+++ b/spec/resources/manifests/test_depositor/test_collection/_EM_test_depositor_test_collection.json
@@ -3,9 +3,6 @@
   "collection_id": "test_collection",
   "steward": "t123",
   "documentation": "cular:test",
-  "locations": [
-    "s3://bogus-bucket/test_depositor/test_collection"
-  ],
   "number_packages": 2,
   "packages": [
     {

--- a/spec/resources/manifests/test_depositor_2/test_collection/_EM_test_depositor_2_test_collection.json
+++ b/spec/resources/manifests/test_depositor_2/test_collection/_EM_test_depositor_2_test_collection.json
@@ -3,9 +3,6 @@
   "collection_id": "test_collection",
   "steward": "t123",
   "documentation": "cular:test",
-  "locations": [
-    "s3://bogus-bucket/test_depositor/test_collection"
-  ],
   "number_packages": 2,
   "packages": [
     {

--- a/spec/resources/misc/collection_manifest.json
+++ b/spec/resources/misc/collection_manifest.json
@@ -3,18 +3,6 @@
     "phys_coll_id": "RMA02471",
     "steward": "eef46",
     "number_files": 2,
-    "locations": {
-      "s3": [
-        {
-          "uri": "s3://s3-cular/RMC/RMA/RMA03487_Cornell_University_Facilities_Construction_Records"
-        }
-      ],
-      "sfs": [
-        {
-          "uri": "smb://files.cornell.edu/lib/archival02/RMC/RMA/RMA03487_Cornell_University_Facilities_Construction_Records"
-        }
-      ]
-    },
     "items": {
       "1001_Barton Hall": {
         "SUCF 161001 10069_2016_Flooring System Replacement": {

--- a/spec/resources/preingest/periodic_fixity/manifests/_EM_test_depositor_next_test_collection_next.json
+++ b/spec/resources/preingest/periodic_fixity/manifests/_EM_test_depositor_next_test_collection_next.json
@@ -2,10 +2,6 @@
   "steward": "t123",
   "depositor": "test_depositor_next",
   "collection_id": "test_collection_next",
-  "locations": [
-    "s3://some_bucket/test_depositor_next/test_collection_next",
-    "smb://files.cornell.edu/lib/archival0x/test_depositor_next/test_collection_next"
-  ],
   "documentation": "cular:xxxx",
   "number_packages": 2,
   "packages": [

--- a/spec/resources/preingest/source_data/_EM_collection_manifest.json
+++ b/spec/resources/preingest/source_data/_EM_collection_manifest.json
@@ -2,10 +2,6 @@
   "steward": "t123",
   "depositor": "test_depositor",
   "collection_id": "test_collection",
-  "locations": [
-    "s3://some_bucket/test_depositor/test_collection",
-    "smb://files.cornell.edu/lib/archival0x/test_depositor/test_collection"
-  ],
   "documentation": "cular:xxxx",
   "number_packages": 2,
   "packages": [

--- a/spec/resources/preingest/source_data/_EM_merged_collection_manifest.json
+++ b/spec/resources/preingest/source_data/_EM_merged_collection_manifest.json
@@ -2,10 +2,6 @@
   "steward": "t123",
   "depositor": "test_depositor",
   "collection_id": "test_collection",
-  "locations": [
-    "s3://some_bucket/test_depositor/test_collection",
-    "smb://files.cornell.edu/lib/archival0x/test_depositor/test_collection"
-  ],
   "documentation": "cular:xxxx",
   "number_packages": 4,
   "packages": [

--- a/spec/resources/preingest/source_data/_EM_unmerged_new_collection_manifest.json
+++ b/spec/resources/preingest/source_data/_EM_unmerged_new_collection_manifest.json
@@ -2,10 +2,6 @@
   "steward": "t123",
   "depositor": "test_depositor",
   "collection_id": "test_collection",
-  "locations": [
-    "s3://some_bucket/test_depositor/test_collection",
-    "smb://files.cornell.edu/lib/archival0x/test_depositor/test_collection"
-  ],
   "documentation": "cular:xxxx",
   "number_packages": 2,
   "packages": [

--- a/spec/resources/schema/manifest_schema_storage.json
+++ b/spec/resources/schema/manifest_schema_storage.json
@@ -17,9 +17,6 @@
             "type": "string",
             "minLength": 2
         },
-        "locations": {
-            "$ref": "#/definitions/locations"
-        },
         "packages": {
             "type": "array",
             "items": {
@@ -39,13 +36,6 @@
     ],
     "additionalProperties": false,
     "definitions": {
-        "locations": {
-            "type": "array",
-            "items": {
-                "type": "string",
-                "pattern": "^s3://.+|^smb://files.cornell.edu/lib/.+"
-            }
-        },
         "package": {
             "type": "object",
             "properties": {
@@ -58,9 +48,6 @@
                 },
                 "local_id": {
                     "type": "string"
-                },
-                "locations": {
-                    "$ref": "#/definitions/locations"
                 },
                 "files": {
                     "type": "array",


### PR DESCRIPTION
https://culibrary.atlassian.net/browse/CULAR-5226

I've tried to remove locations from the code that creates or updates the manifests. There are still some location-related functions present that connect to the larger thread of SFS-related code; these could presumably also be removed, but that's a much larger undertaking, and I don't think they should matter for this.