### PR TITLE
Remove remaining SFS reference

### DIFF
--- a/exe/archival_storage_periodic_fixity_check
+++ b/exe/archival_storage_periodic_fixity_check
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # #!/usr/bin/env ruby
 # # frozen_string_literal: true
 #

--- a/exe/archival_storage_server_ingest_fixity_comparison
+++ b/exe/archival_storage_server_ingest_fixity_comparison
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # #!/usr/bin/env ruby
 # # frozen_string_literal: true
 

--- a/exe/archival_storage_server_periodic_fixity_comparison
+++ b/exe/archival_storage_server_periodic_fixity_comparison
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # #!/usr/bin/env ruby
 # # frozen_string_literal: true
 #

--- a/exe/deploy_collection_manifest
+++ b/exe/deploy_collection_manifest
@@ -13,7 +13,7 @@ class StorageManifestDeployer < BaseManifestDeployer
   def _manifest_deployer
     Manifests::CollectionManifestDeployer.new(
       manifests_path: manifest_of_manifests, s3_manager:, s3_west_manager:, wasabi_manager:,
-      sfs_prefix:, manifest_validator:, file_identifier:, manifest_storage_manager:
+      manifest_validator:, file_identifier:, manifest_storage_manager:
     )
   end
 end
@@ -22,7 +22,6 @@ end
 # https://www.ruby-forum.com/t/argv-stdin-and-gets/166427/3
 new_collection_manifest = ARGV.shift
 ingest_manifest = ARGV.shift
-sfs = ARGV.shift
 
 skip_data_addition = ARGV.shift
 skip_data_addition = !(skip_data_addition.nil? || skip_data_addition != 'true')
@@ -30,7 +29,7 @@ skip_data_addition = !(skip_data_addition.nil? || skip_data_addition != 'true')
 manifest_deployer = StorageManifestDeployer.new
 manifest_parameters = Manifests::ManifestParameters.new(
   storage_manifest_path: new_collection_manifest,
-  ingest_manifest_path: ingest_manifest, sfs:, skip_data_addition:
+  ingest_manifest_path: ingest_manifest, skip_data_addition:
 )
 
 # puts 'Deployment Summary'

--- a/exe/deploy_collection_manifest
+++ b/exe/deploy_collection_manifest
@@ -23,9 +23,6 @@ end
 new_collection_manifest = ARGV.shift
 ingest_manifest = ARGV.shift
 sfs = ARGV.shift
-# TODO:  archives_list is no longer used, so this should be removed. It's being kept for the moment to ensure
-# that the script doesn't break because of the missing ARGV.shift.
-archives_list = ARGV.shift || 'archival01,archival02,archival03,archival04,archival05,archival06,archival07'
 
 skip_data_addition = ARGV.shift
 skip_data_addition = !(skip_data_addition.nil? || skip_data_addition != 'true')

--- a/exe/setup_ingest_env
+++ b/exe/setup_ingest_env
@@ -19,20 +19,12 @@ STORAGE_MANIFEST_SCHEMA = ENV['STORAGE_MANIFEST_SCHEMA'] || Manifests::ManifestV
 INGEST_MANIFEST_SCHEMA = ENV['INGEST_MANIFEST_SCHEMA'] || Manifests::ManifestValidator::DEFAULT_INGEST_SCHEMA
 INGEST_ROOT = ENV['INGEST_ROOT'] || '/cul/app/archival_storage_ingest/ingest'
 WASABI_BUCKET = ENV['WASABI_BUCKET'] || 'wasabi-cular'
-SFS_PREFIX = if ENV['SFS_PREFIX']
-               ENV['SFS_PREFIX']
-             elsif ENV['asi_develop'] || ENV['asi_deploy_manifest_develop']
-               '/cul/app/archival_storage_ingest/test/deploy'
-             else
-               Manifests::DEFAULT_SFS_PREFIX
-             end
-file_identifier = Manifests::FileIdentifier.new(sfs_prefix: SFS_PREFIX, java_path: JAVA_PATH,
-                                                tika_path: TIKA_PATH)
+
+file_identifier = Manifests::FileIdentifier.new(java_path: JAVA_PATH, tika_path: TIKA_PATH)
 manifest_validator = Manifests::ManifestValidator.new(storage_schema: STORAGE_MANIFEST_SCHEMA,
                                                       ingest_schema: INGEST_MANIFEST_SCHEMA)
 wasabi_manager = WasabiManager.new(WASABI_BUCKET)
 env_initializer = Preingest::IngestEnvInitializer.new(ingest_root: INGEST_ROOT,
-                                                      sfs_root: SFS_PREFIX,
                                                       file_identifier:,
                                                       manifest_validator:,
                                                       wasabi_manager:)

--- a/exe/setup_periodic_fixity_env
+++ b/exe/setup_periodic_fixity_env
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
+
 #
 # NOTE: Disabled because PeriodicFixityEnvInitializer relies on SFS.
 

--- a/lib/archival_storage_ingest/manifests/base_manifest_deployer.rb
+++ b/lib/archival_storage_ingest/manifests/base_manifest_deployer.rb
@@ -9,7 +9,7 @@ require 'archival_storage_ingest/wasabi/wasabi_manager'
 
 class BaseManifestDeployer # rubocop:disable Metrics/ClassLength
   attr_writer :storage_schema, :ingest_schema, :java_path, :tika_path, :file_identifier, :manifest_of_manifests,
-              :s3_bucket, :asif_bucket, :asif_archive_size_bucket, :s3_manager, :sfs_prefix,
+              :s3_bucket, :asif_bucket, :asif_archive_size_bucket, :s3_manager,
               :manifest_validator, :skip_data_addition, :manifest_deployer, :archives, :archive_size
 
   def storage_schema
@@ -49,8 +49,7 @@ class BaseManifestDeployer # rubocop:disable Metrics/ClassLength
   end
 
   def _file_identifier
-    Manifests::FileIdentifier.new(java_path:, tika_path:,
-                                  sfs_prefix:)
+    Manifests::FileIdentifier.new(java_path:, tika_path:)
   end
 
   def manifest_of_manifests
@@ -136,18 +135,6 @@ class BaseManifestDeployer # rubocop:disable Metrics/ClassLength
 
   def _wasabi_manager
     WasabiManager.new(wasabi_bucket)
-  end
-
-  def sfs_prefix
-    @sfs_prefix ||= _sfs_prefix
-  end
-
-  def _sfs_prefix
-    if ENV['asi_develop'] || ENV['asi_deploy_manifest_develop']
-      '/cul/app/archival_storage_ingest/test/deploy'
-    else
-      Manifests::DEFAULT_SFS_PREFIX
-    end
   end
 
   def manifest_storage_manager

--- a/lib/archival_storage_ingest/manifests/deploy_collection_manifest.rb
+++ b/lib/archival_storage_ingest/manifests/deploy_collection_manifest.rb
@@ -10,16 +10,16 @@ module Manifests
   # collection manifest is old term for storage manifest
   # in the future, we may refactor reference to collection manifest to storage manifest
   class CollectionManifestDeployer
-    attr_reader :file_identifier, :manifest_of_manifests, :manifest_validator, :sfs_prefix
+    attr_reader :file_identifier, :manifest_of_manifests, :manifest_validator
 
     # initialize accepts these keys:
     # manifest_path, s3_manager, s3_west_manager, wasabi_manager, manifest_storage_manager
     # manifest_validator - uses default one in production, specify one for testing
-    # sfs_prefix, java_path, tika_path - uses default values in production, specify them for testing
+    # java_path, tika_path - uses default values in production, specify them for testing
     #                                    these are used to initialize FileIdentifier
     # rubocop:disable Metrics/ParameterLists
     def initialize(manifests_path:, s3_manager:, s3_west_manager:, wasabi_manager:, manifest_storage_manager:,
-                   file_identifier:, sfs_prefix:, manifest_validator: Manifests::ManifestValidator.new)
+                   file_identifier:, manifest_validator: Manifests::ManifestValidator.new)
       @mom_path = manifests_path
       @manifest_of_manifests = Manifests::ManifestOfManifests.new(manifests_path)
 
@@ -29,7 +29,6 @@ module Manifests
       @manifest_storage_manager = manifest_storage_manager
       @file_identifier = file_identifier
       @manifest_validator = manifest_validator
-      @sfs_prefix = sfs_prefix
     end
     # rubocop:enable Metrics/ParameterLists
 
@@ -39,8 +38,7 @@ module Manifests
                                                                collection: manifest_parameters.collection_id)
 
       if manifest_def.nil?
-        manifest_of_manifests.add_manifest_definition(storage_manifest_path: manifest_parameters.storage_manifest_path,
-                                                      sfs: manifest_parameters.sfs)
+        manifest_of_manifests.add_manifest_definition(storage_manifest_path: manifest_parameters.storage_manifest_path)
       else
         manifest_def.sha1 = IngestUtils.calculate_checksum(filepath: manifest_parameters.storage_manifest_path)[0]
         manifest_def
@@ -163,11 +161,11 @@ module Manifests
     end
   end
 
-  # storage_manifest_path:, ingest_manifest_path:, sfs: nil, ingest_date: nil,
+  # storage_manifest_path:, ingest_manifest_path:, ingest_date: nil,
   # skip_data_addition: false
   class ManifestParameters
     attr_reader :storage_manifest_path, :ingest_manifest_path,
-                :ingest_manifest, :sfs, :skip_data_addition, :ingest_date
+                :ingest_manifest, :skip_data_addition, :ingest_date
     attr_accessor :storage_manifest
 
     def initialize(named_params)
@@ -176,7 +174,6 @@ module Manifests
       @ingest_manifest_path = resolve_ingest_manifest_path(named_params)
       @ingest_manifest = resolve_ingest_manifest(source: @ingest_manifest_path)
       @ingest_date = named_params.fetch(:ingest_date, nil)
-      @sfs = named_params.fetch(:sfs, nil)
       @skip_data_addition = named_params.fetch(:skip_data_addition, false)
     end
 

--- a/lib/archival_storage_ingest/manifests/manifest_of_manifests.rb
+++ b/lib/archival_storage_ingest/manifests/manifest_of_manifests.rb
@@ -4,14 +4,12 @@ require 'archival_storage_ingest/ingest_utils/ingest_utils'
 require 'json'
 
 module Manifests
-  def self.create_manifest_definition(storage_manifest_path:, sfs:)
-    abort 'sfs must be provided for new collection!' if IngestUtils.blank?(sfs)
-
+  def self.create_manifest_definition(storage_manifest_path:)
     storage_manifest = Manifests.read_manifest(filename: storage_manifest_path)
     depositor = storage_manifest.depositor
     collection = storage_manifest.collection_id
     params = { depositor:, collection:, path: File.basename(storage_manifest_path),
-               sha1: IngestUtils.calculate_checksum(filepath: storage_manifest_path)[0], sfs: [sfs],
+               sha1: IngestUtils.calculate_checksum(filepath: storage_manifest_path)[0],
                s3_key: "#{depositor}/#{collection}/#{File.basename(storage_manifest_path)}",
                depcol: "#{depositor}/#{collection}" }
     ManifestDefinition.new(params)
@@ -41,8 +39,8 @@ module Manifests
       manifest_of_manifests[index + 1]
     end
 
-    def add_manifest_definition(storage_manifest_path:, sfs:)
-      new_manifest_def = Manifests.create_manifest_definition(storage_manifest_path:, sfs:)
+    def add_manifest_definition(storage_manifest_path:)
+      new_manifest_def = Manifests.create_manifest_definition(storage_manifest_path:)
       @manifest_of_manifests << new_manifest_def
 
       new_manifest_def
@@ -65,13 +63,12 @@ module Manifests
   end
 
   class ManifestDefinition
-    attr_accessor :depositor, :collection, :sha1, :sfs, :depcol, :path, :s3_key
+    attr_accessor :depositor, :collection, :sha1, :depcol, :path, :s3_key
 
     def initialize(manifest_def_hash)
       @depositor = manifest_def_hash[:depositor]
       @collection = manifest_def_hash[:collection]
       @sha1 = manifest_def_hash[:sha1]
-      @sfs = manifest_def_hash[:sfs]
       @depcol = manifest_def_hash[:depcol]
       @path = manifest_def_hash[:path]
       @s3_key = manifest_def_hash[:s3_key]
@@ -79,7 +76,7 @@ module Manifests
 
     def to_hash
       {
-        depositor:, collection:, sha1:, sfs:,
+        depositor:, collection:, sha1:,
         depcol:, path:, s3_key:
       }.compact
     end

--- a/lib/archival_storage_ingest/manifests/manifests.rb
+++ b/lib/archival_storage_ingest/manifests/manifests.rb
@@ -453,8 +453,6 @@ module Manifests
 
       stdout, _stderr, status = Open3.capture3(java_path, '-jar', tika_path, '-x', '-d', abs_path)
 
-      puts "#{java_path} -jar #{tika_path} -x -d #{abs_path} : #{status.success}"
-
       return stdout.chomp if status.success?
 
       'application/octet-stream'

--- a/lib/archival_storage_ingest/options/command_parser.rb
+++ b/lib/archival_storage_ingest/options/command_parser.rb
@@ -144,31 +144,4 @@ module CommandParser
       IngestUtils.blank?(param) ? if_blank : param
     end
   end
-
-  class SetupPeriodicFixityEnvCommandParser
-    attr_reader :storage_manifest, :ticket_id, :sfs_bucket
-
-    def parse!(args)
-      OptionParser.new do |opts|
-        opts.banner = 'Usage: setup_ingest_env -s -f -t -p -b'
-
-        # Required parameters
-        opts.on('-s', '--storage_manifest [String]', 'Storage manifest') { |s| @storage_manifest = s }
-        opts.on('-t', '--ticket_id [String]', 'Ticket ID') { |t| @ticket_id = t }
-        opts.on('-b', '--sfs_bucket [String]', 'SFS bucket') { |b| @sfs_bucket = b }
-
-        # Optional parameters, default values will be used if not specified
-        opts.on('-f', '--sfs_root [String]', 'SFS root') { |f| @sfs_root = f }
-        opts.on('-p', '--periodic_fixity_root [String]', 'Periodic fixity root') { |p| @periodic_fixity_root = p }
-      end.parse!(args)
-    end
-
-    def periodic_fixity_root
-      @periodic_fixity_root ||= Preingest::DEFAULT_FIXITY_ROOT
-    end
-
-    def sfs_root
-      @sfs_root ||= Preingest::DEFAULT_SFS_ROOT
-    end
-  end
 end

--- a/lib/archival_storage_ingest/preingest/base_env_initializer.rb
+++ b/lib/archival_storage_ingest/preingest/base_env_initializer.rb
@@ -6,18 +6,15 @@ require 'yaml'
 
 module Preingest
   DEFAULT_INGEST_ROOT = '/cul/app/archival_storage_ingest/ingest'
-  DEFAULT_FIXITY_ROOT = '/cul/app/archival_storage_ingest/periodic_fixity'
-  DEFAULT_SFS_ROOT    = '/cul/data'
   NO_COLLECTION_MANIFEST = 'none'
 
   class BaseEnvInitializer
     attr_accessor :total_size, :size_mismatch
-    attr_reader :ingest_root, :sfs_root, :depositor, :collection_id, :ingest_params,
+    attr_reader :ingest_root, :depositor, :collection_id, :ingest_params,
                 :collection_root, :data_root
 
-    def initialize(ingest_root:, sfs_root:)
+    def initialize(ingest_root:)
       @ingest_root   = ingest_root
-      @sfs_root      = sfs_root
       @ingest_params = nil
       @total_size    = 0
       @size_mismatch = {}
@@ -76,10 +73,6 @@ module Preingest
     end
 
     def generate_config(ingest_manifest_path:); end
-
-    def dest_path(sfs_location:)
-      raise "Do something with #{sfs_location}!"
-    end
 
     def work_type; end
 

--- a/lib/archival_storage_ingest/preingest/ingest_env_initializer.rb
+++ b/lib/archival_storage_ingest/preingest/ingest_env_initializer.rb
@@ -153,12 +153,7 @@ module Preingest
 
     def generate_config(ingest_manifest_path:)
       { type: work_type, depositor:, collection: collection_id,
-        dest_path: dest_path(sfs_location: ingest_params.sfsbucket),
         ingest_manifest: ingest_manifest_path, ticket_id: ingest_params.ticketid }
-    end
-
-    def dest_path(sfs_location:)
-      File.join(sfs_root, sfs_location, depositor, collection_id)
     end
 
     def work_type

--- a/lib/archival_storage_ingest/preingest/ingest_env_initializer.rb
+++ b/lib/archival_storage_ingest/preingest/ingest_env_initializer.rb
@@ -17,8 +17,8 @@ module Preingest
   class IngestEnvInitializer < BaseEnvInitializer # rubocop:disable Metrics/ClassLength
     attr_reader :file_identifier, :manifest_validator, :wasabi_manager
 
-    def initialize(ingest_root:, sfs_root:, manifest_validator:, file_identifier:, wasabi_manager:)
-      super(ingest_root:, sfs_root:)
+    def initialize(ingest_root:, manifest_validator:, file_identifier:, wasabi_manager:)
+      super(ingest_root:)
 
       @file_identifier = file_identifier
       @manifest_validator = manifest_validator

--- a/lib/archival_storage_ingest/preingest/periodic_fixity_env_initializer.rb
+++ b/lib/archival_storage_ingest/preingest/periodic_fixity_env_initializer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # # frozen_string_literal: true
 
 # NOTE: PeriodicFixityEnvInitializer disabled because it relies on SFS.

--- a/lib/archival_storage_ingest/s3/s3_manager.rb
+++ b/lib/archival_storage_ingest/s3/s3_manager.rb
@@ -170,4 +170,11 @@ class S3Manager # rubocop:disable Metrics/ClassLength
 
     num_deleted
   end
+
+  def exists?(key:)
+    s3.head_object(bucket: @s3_bucket, key:)
+    true
+  rescue Aws::S3::Errors::NotFound
+    false
+  end
 end

--- a/lib/archival_storage_ingest/work_queuer/input_checker.rb
+++ b/lib/archival_storage_ingest/work_queuer/input_checker.rb
@@ -14,30 +14,10 @@ module WorkQueuer
     # Check whether path/files in ingest_config are actual path/files.
     # Override this method if additional checks are required.
     def check_input(ingest_config)
-      # if dest_path is blank, use empty string '' to avoid errors printing it
-      dest_path = IngestUtils.if_empty(ingest_config[:dest_path], '')
-      @errors << "dest_path '#{dest_path}' does not exist!" unless
-        dest_path_ok?(dest_path)
-
       @errors << "Queue name #{ingest_config[:queue_name]} is not valid!" unless
         valid_queue_name?(ingest_config[:queue_name])
 
       @errors.empty?
-    end
-
-    def dest_path_ok?(dest_path)
-      return true if File.exist?(dest_path)
-
-      # We store data under /cul/data/archivalxx/DEPOSITOR/COLLECTION
-      # If we can find up to archivalxx, we should be OK.
-      # We may need to change this behavior when we adopt OCFL.
-      without_collection = File.dirname(dest_path)
-      without_depositor  = File.dirname(without_collection)
-
-      # The most likely case for '.' is when dest_path is blank.
-      return false if without_depositor == '.'
-
-      File.exist?(without_depositor)
     end
 
     def valid_queue_name?(queue_name)

--- a/lib/archival_storage_ingest/work_queuer/work_queuer.rb
+++ b/lib/archival_storage_ingest/work_queuer/work_queuer.rb
@@ -59,8 +59,7 @@ module WorkQueuer
         type: work_type, ticket_id: ingest_config[:ticket_id],
         job_id: ingest_config[:job_id].nil? ? SecureRandom.uuid : ingest_config[:job_id],
         depositor: ingest_config[:depositor], collection: ingest_config[:collection],
-        dest_path: ingest_config[:dest_path], ingest_manifest: ingest_config[:ingest_manifest],
-        worker: 'Ingest Queuer'
+        ingest_manifest: ingest_config[:ingest_manifest], worker: 'Ingest Queuer'
       )
       q_name = ingest_config[:queue_name].nil? ? @queue_name : ingest_config[:queue_name]
       @queuer.put_message(q_name, msg)

--- a/lib/archival_storage_ingest/workers/fixity_compare_worker.rb
+++ b/lib/archival_storage_ingest/workers/fixity_compare_worker.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # # frozen_string_literal: true
 #
 # NOTE: ManifestComparator is premised on making comparisons to the SFS manifest. Since SFS storage

--- a/lib/archival_storage_ingest/workers/transfer_worker.rb
+++ b/lib/archival_storage_ingest/workers/transfer_worker.rb
@@ -126,6 +126,8 @@ module TransferWorker
     # source is absolute file path of the asset
     # target is s3_key
     def process_file(source:, target:)
+      raise IngestException, "#{target} already exists in #{_platform}" if s3_manager.exists?(key: target)
+
       s3_manager.upload_file(target, source)
     end
 
@@ -170,6 +172,8 @@ module TransferWorker
     # source is absolute file path of the asset
     # target is s3_key
     def process_file(source:, target:)
+      raise IngestException, "#{target} already exists in #{_platform}" if wasabi_manager.exists?(key: target)
+
       wasabi_manager.upload_file(target, source)
     end
 

--- a/spec/archival_storage_ingest_spec.rb
+++ b/spec/archival_storage_ingest_spec.rb
@@ -50,17 +50,11 @@ RSpec.describe ArchivalStorageIngest do
     context 'when not supplying required fields' do
       it 'returns errors' do
         input_checker = WorkQueuer::IngestInputChecker.new
-        empty_dest_path = input_checker.check_input(job_id: 'test_id',
-                                                    ingest_manifest: 'bogus_path')
-        expect(empty_dest_path).to be(false)
-        expect(input_checker.errors.size).to eq(2)
-
-        input_checker = WorkQueuer::IngestInputChecker.new
         invalid_dest_path = input_checker.check_input(job_id: 'test_id',
                                                       dest_path: 'bogus_path',
                                                       ingest_manifest: 'bogus_path')
         expect(invalid_dest_path).to be(false)
-        expect(input_checker.errors.size).to eq(2)
+        expect(input_checker.errors.size).to eq(1)
 
         # Both of these errors are invalid source_path errors.
         # I don't know how to efficiently test the success case as the test ingest manifest FILE

--- a/spec/deploy_collection_manifest_spec.rb
+++ b/spec/deploy_collection_manifest_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'CollectionManifestDeployer' do
   let(:man_of_man_source) { resolve_filename(%w[manifests manifest_of_manifest.json]) }
   let(:man_of_man) { resolve_filename(%w[manifests manifest_of_manifest_copy.json]) }
   let(:old_manifest_sha1) { 'deadbeef' }
-  let(:new_manifest_sha1) { '1d2fcfde749ba5c0c04458e88544d5f935a120f8' }
+  let(:new_manifest_sha1) { 'c0c0af5c300491abde9aa8a8678d44bf99c90121' }
   let(:asif_bucket) { 's3-cular-invalid' }
   let(:s3_manager) do
     local_root = File.join(File.dirname(__FILE__), 'resources', 'cloud')
@@ -60,12 +60,12 @@ RSpec.describe 'CollectionManifestDeployer' do
     LocalManager.new(local_root:, type: TYPE_VERSIONED_MANIFEST)
   end
   let(:ingest_date) { '2020-09-08' }
+  # sfs_prefix is still used as temporary storage for the collection manifests
   let(:sfs_prefix) { File.join(File.dirname(__FILE__), 'resources', 'manifests', 'manifest_deployer', 'sfs') }
   let(:source_path) { File.join(File.dirname(__FILE__), 'resources', 'data', 'test_depositor', 'test_collection') }
   let(:file_identifier) do
-    fi = Manifests::FileIdentifier.new(sfs_prefix: 'bogus')
+    fi = Manifests::FileIdentifier.new
     allow(fi).to receive(:identify_from_source).with(any_args).and_return('text/plain')
-    allow(fi).to receive(:identify_from_storage).with(any_args).and_return('text/plain')
     fi
   end
   let(:manifest_validator) do

--- a/spec/deploy_collection_manifest_spec.rb
+++ b/spec/deploy_collection_manifest_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe 'CollectionManifestDeployer' do
     FileUtils.mkdir_p File.join(sfs_prefix, 'archivalyy', 'test_depositor_2', 'test_collection')
     @deployer = Manifests::CollectionManifestDeployer.new(
       manifests_path: man_of_man, s3_manager:, s3_west_manager:, manifest_validator:,
-      file_identifier:, sfs_prefix:, wasabi_manager:, manifest_storage_manager:
+      file_identifier:, wasabi_manager:, manifest_storage_manager:
     )
   end
 
@@ -107,23 +107,10 @@ RSpec.describe 'CollectionManifestDeployer' do
     it 'returns added definition when not found' do
       manifest_params = Manifests::ManifestParameters.new(storage_manifest_path: td2_storage_manifest_path,
                                                           ingest_manifest_path: td2_ingest_manifest_path,
-                                                          ingest_date:,
-                                                          sfs: 'archivalyy')
+                                                          ingest_date:)
       puts manifest_params.storage_manifest.depositor
       manifest_def = @deployer.prepare_manifest_definition(manifest_parameters: manifest_params)
-      expect(manifest_def.sfs[0]).to eq('archivalyy')
-    end
-
-    it 'aborts if sfs is not supplied for new collection' do
-      manifest_params = Manifests::ManifestParameters.new(storage_manifest_path: td2_storage_manifest_path,
-                                                          ingest_manifest_path: td2_ingest_manifest_path,
-                                                          ingest_date:)
-      expect do
-        manifest_params = Manifests::ManifestParameters.new(storage_manifest_path: td2_storage_manifest_path,
-                                                            ingest_manifest_path: td2_storage_manifest_path,
-                                                            ingest_date:)
-        @deployer.prepare_manifest_definition(manifest_parameters: manifest_params)
-      end.to raise_error(SystemExit)
+      expect(manifest_def.s3_key).to eq('test_depositor_2/test_collection/_EM_test_depositor_2_test_collection.json')
     end
   end
 
@@ -149,8 +136,7 @@ RSpec.describe 'CollectionManifestDeployer' do
       expect(mom.size).to eq(1)
       manifest_params = Manifests::ManifestParameters.new(storage_manifest_path: td2_storage_manifest_path,
                                                           ingest_manifest_path: td2_ingest_manifest_path,
-                                                          ingest_date:,
-                                                          sfs: 'archivalyy')
+                                                          ingest_date:)
       manifest_definition = @deployer.prepare_manifest_definition(manifest_parameters: manifest_params)
       @deployer.deploy_collection_manifest(manifest_def: manifest_definition,
                                            collection_manifest: td2_storage_manifest_path)
@@ -159,7 +145,6 @@ RSpec.describe 'CollectionManifestDeployer' do
       expect(File.file? expected_file).to be_truthy
       mom = get_mom(man_of_man)
       expect(mom.size).to eq(2)
-      expect(mom[1][:sfs][0]).to eq('archivalyy')
     end
   end
 end

--- a/spec/ingest_env_initializer_spec.rb
+++ b/spec/ingest_env_initializer_spec.rb
@@ -125,7 +125,6 @@ RSpec.describe 'IngestEnvInitializer' do
       expect(got_yaml[:type]).to eq(expected_yaml[:type])
       expect(got_yaml[:depositor]).to eq(expected_yaml[:depositor])
       expect(got_yaml[:collection]).to eq(expected_yaml[:collection])
-      expect(got_yaml[:dest_path]).to eq(expected_yaml[:dest_path])
       expect(got_yaml[:ingest_manifest]).to eq(expected_yaml[:ingest_manifest])
       expect(got_yaml[:ticket_id]).to eq(expected_yaml[:ticket_id])
     end

--- a/spec/ingest_env_initializer_spec.rb
+++ b/spec/ingest_env_initializer_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe 'IngestEnvInitializer' do
   let(:base_dir) { File.dirname(__FILE__) }
 
   let(:ingest_root) { File.join(base_dir, 'resources', 'preingest', 'ingest_root') }
-  let(:sfs_root) { File.join(base_dir, 'resources', 'preingest', 'sfs_root') }
   let(:source_data) { File.join(base_dir, 'resources', 'preingest', 'source_data') }
   let(:storage_manifest_filename) { '_EM_test_depositor_test_collection.json' }
   let(:storage_manifest) { File.join(source_data, '_EM_collection_manifest.json') }
@@ -44,9 +43,8 @@ RSpec.describe 'IngestEnvInitializer' do
   let(:ingest_schema) { File.join(base_dir, 'resources', 'schema', 'manifest_schema_ingest.json') }
   let(:manifest_validator) { Manifests::ManifestValidator.new(ingest_schema:, storage_schema:) }
   let(:file_identifier) do
-    fi = Manifests::FileIdentifier.new(sfs_prefix: 'bogus')
+    fi = Manifests::FileIdentifier.new
     allow(fi).to receive(:identify_from_source).with(any_args).and_return('text/plain')
-    allow(fi).to receive(:identify_from_storage).with(any_args).and_return('text/plain')
     fi
   end
   let(:ingest_params_path) { File.join(source_data, 'ingest.conf') }
@@ -75,7 +73,7 @@ RSpec.describe 'IngestEnvInitializer' do
   context 'when initializing ingest env' do
     it 'creates ingest env' do
       env_initializer = Preingest::IngestEnvInitializer.new(
-        ingest_root:, sfs_root:, manifest_validator:, file_identifier:, wasabi_manager:)
+        ingest_root:, manifest_validator:, file_identifier:, wasabi_manager:)
       # env_initializer.initialize_ingest_env(data:, cmf: collection_manifest, imf: ingest_manifest,
       #                                       sfs_location:, ticket_id:,
       #                                       depositor:, collection_id: collection)
@@ -118,7 +116,6 @@ RSpec.describe 'IngestEnvInitializer' do
       expect(got_mm.number_packages).to eq(expected_mm.number_packages)
 
       expected_yaml = YAML.load_file(expected_ingest_config)
-      expected_yaml[:dest_path] = File.join(sfs_root, expected_yaml[:dest_path])
       expected_yaml[:ingest_manifest] = File.join(got_manifest_path, 'ingest_manifest', expected_yaml[:ingest_manifest])
       got_yaml_path = File.join(got_path, 'config', 'ingest_config.yaml')
       got_yaml = YAML.load_file(got_yaml_path)

--- a/spec/manifest_missing_attribute_populator_spec.rb
+++ b/spec/manifest_missing_attribute_populator_spec.rb
@@ -59,14 +59,14 @@ RSpec.describe 'ManifestMissingAttributePopulator' do
               filepath: '1/one.txt',
               sha1: 'ef72cf86c1599c80612317fdd2f50f4863c3efb0',
               size: 10,
-              tool_version: 'Apache Tika 2.1.0',
+              tool_version: 'Apache Tika 2.9.2',
               media_type: 'text/plain'
             },
             {
               filepath: '2/two.txt',
               sha1: '158481d59505dedf144ec5e4b87e92043f48ab68',
               size: 10,
-              tool_version: 'Apache Tika 2.1.0',
+              tool_version: 'Apache Tika 2.9.2',
               media_type: 'text/plain'
             }
           ]
@@ -80,7 +80,7 @@ RSpec.describe 'ManifestMissingAttributePopulator' do
               filepath: '1/one.txt',
               sha1: 'ef72cf86c1599c80612317fdd2f50f4863c3efb0',
               size: 10,
-              tool_version: 'Apache Tika 2.1.0',
+              tool_version: 'Apache Tika 2.9.2',
               media_type: 'text/plain'
             }
           ]
@@ -89,9 +89,8 @@ RSpec.describe 'ManifestMissingAttributePopulator' do
     }
   end
   let(:file_identifier) do
-    fi = Manifests::FileIdentifier.new(sfs_prefix: 'bogus')
+    fi = Manifests::FileIdentifier.new
     allow(fi).to receive(:identify_from_source).with(any_args).and_return('text/plain')
-    allow(fi).to receive(:identify_from_storage).with(any_args).and_return('text/plain')
     fi
   end
 

--- a/spec/resources/manifests/test_depositor/test_collection/_EM_test_depositor_test_collection.json
+++ b/spec/resources/manifests/test_depositor/test_collection/_EM_test_depositor_test_collection.json
@@ -14,7 +14,7 @@
           "sha1": "c7059bb19433cc3cabaa6236c83d56668a843dd2",
           "size": 4,
           "ingest_date": "2020-09-08",
-          "tool_version": "Apache Tika 2.1.0",
+          "tool_version": "Apache Tika 2.9.2",
           "media_type": "text/plain"
         },
         {
@@ -22,7 +22,7 @@
           "sha1": "f7aa11a22a605d4655e1d1ae122ceb43ddcfe5a9",
           "size": 16,
           "ingest_date": "2020-09-08",
-          "tool_version": "Apache Tika 2.1.0",
+          "tool_version": "Apache Tika 2.9.2",
           "media_type": "text/plain"
         },
         {
@@ -30,7 +30,7 @@
           "sha1": "6662c3da403be36f1b24a6e8c3fa42f7f4215066",
           "size": 16,
           "ingest_date": "2020-09-08",
-          "tool_version": "Apache Tika 2.1.0",
+          "tool_version": "Apache Tika 2.9.2",
           "media_type": "text/plain"
         }
       ]
@@ -44,7 +44,7 @@
           "sha1": "7bbef45b3bc70855010e02460717643125c3beca",
           "size": 4,
           "ingest_date": "2020-09-08",
-          "tool_version": "Apache Tika 2.1.0",
+          "tool_version": "Apache Tika 2.9.2",
           "media_type": "text/plain"
         },
         {
@@ -52,7 +52,7 @@
           "sha1": "5d64b71392b1e00a3ad893db02d381d58262c2d6",
           "size": 7,
           "ingest_date": "2020-09-08",
-          "tool_version": "Apache Tika 2.1.0",
+          "tool_version": "Apache Tika 2.9.2",
           "media_type": "text/plain"
         },
         {
@@ -60,7 +60,7 @@
           "sha1": "c5d84736ba451747dd5f0eb9d17e104f3697ef47",
           "size": 5,
           "ingest_date": "2020-09-08",
-          "tool_version": "Apache Tika 2.1.0",
+          "tool_version": "Apache Tika 2.9.2",
           "media_type": "text/plain"
         }
       ]

--- a/spec/resources/manifests/test_depositor_2/test_collection/_EM_test_depositor_2_test_collection.json
+++ b/spec/resources/manifests/test_depositor_2/test_collection/_EM_test_depositor_2_test_collection.json
@@ -14,7 +14,7 @@
           "sha1": "c7059bb19433cc3cabaa6236c83d56668a843dd2",
           "size": 4,
           "ingest_date": "2020-09-08",
-          "tool_version": "Apache Tika 2.1.0",
+          "tool_version": "Apache Tika 2.9.2",
           "media_type": "text/plain"
         },
         {
@@ -22,7 +22,7 @@
           "sha1": "f7aa11a22a605d4655e1d1ae122ceb43ddcfe5a9",
           "size": 16,
           "ingest_date": "2020-09-08",
-          "tool_version": "Apache Tika 2.1.0",
+          "tool_version": "Apache Tika 2.9.2",
           "media_type": "text/plain"
         },
         {
@@ -30,7 +30,7 @@
           "sha1": "6662c3da403be36f1b24a6e8c3fa42f7f4215066",
           "size": 16,
           "ingest_date": "2020-09-08",
-          "tool_version": "Apache Tika 2.1.0",
+          "tool_version": "Apache Tika 2.9.2",
           "media_type": "text/plain"
         }
       ]
@@ -44,7 +44,7 @@
           "sha1": "7bbef45b3bc70855010e02460717643125c3beca",
           "size": 4,
           "ingest_date": "2020-09-08",
-          "tool_version": "Apache Tika 2.1.0",
+          "tool_version": "Apache Tika 2.9.2",
           "media_type": "text/plain"
         },
         {
@@ -52,7 +52,7 @@
           "sha1": "5d64b71392b1e00a3ad893db02d381d58262c2d6",
           "size": 7,
           "ingest_date": "2020-09-08",
-          "tool_version": "Apache Tika 2.1.0",
+          "tool_version": "Apache Tika 2.9.2",
           "media_type": "text/plain"
         },
         {
@@ -60,7 +60,7 @@
           "sha1": "c5d84736ba451747dd5f0eb9d17e104f3697ef47",
           "size": 5,
           "ingest_date": "2020-09-08",
-          "tool_version": "Apache Tika 2.1.0",
+          "tool_version": "Apache Tika 2.9.2",
           "media_type": "text/plain"
         }
       ]


### PR DESCRIPTION
The remaining SFS references for ingest/manifest deployment process is removed.
There may be more references that are not actively used, however.