### PR TITLE
Allow generation of storage manifest when overwrites are detected

### DIFF
--- a/lib/archival_storage_ingest/preingest/ingest_env_initializer.rb
+++ b/lib/archival_storage_ingest/preingest/ingest_env_initializer.rb
@@ -130,13 +130,15 @@ module Preingest
     def _merge_ingest_manifest_to_collection_manifest(imf:)
       cm = _get_storage_manifest
       im = Manifests.read_manifest(filename: imf)
+      manifest = Manifests.merge_manifests(storage_manifest: cm, ingest_manifest: im)
+
       overwrites = overwrite_checker.check_overwrites(ingest_manifest: im)
       if overwrites.any?
         msg = overwrites.join("\n")
         raise IngestException, "Overwrite detected:\n#{msg}"
       end
 
-      Manifests.merge_manifests(storage_manifest: cm, ingest_manifest: im)
+      manifest
     end
 
     def _get_storage_manifest

--- a/lib/archival_storage_ingest/s3/s3_manager.rb
+++ b/lib/archival_storage_ingest/s3/s3_manager.rb
@@ -172,7 +172,7 @@ class S3Manager # rubocop:disable Metrics/ClassLength
   end
 
   def exist?(key:)
-    s3.head_object(bucket: @s3_bucket, key:)
+    s3.client.head_object(bucket: @s3_bucket, key:)
     true
   rescue Aws::S3::Errors::NotFound
     false


### PR DESCRIPTION
Allow generation of storage manifest when overwrites are detected but still halt the ingest process.
It is needed for IPP ingest.